### PR TITLE
Remove typescript-eslint package pattern from groupLinters preset since those are included in `packages:eslint` and `packages:linters` now

### DIFF
--- a/groupLinters.json
+++ b/groupLinters.json
@@ -7,9 +7,6 @@
       ],
       "packageNames": [
         "prettier"
-      ],
-      "packagePatterns": [
-        "^@typescript-eslint/"
       ]
     }
   ]


### PR DESCRIPTION
ref: https://github.com/renovatebot/renovate/pull/6687