### PR TITLE
Follow renaming of :masterIssue preset

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,7 +1,7 @@
 {
   "extends": [
     "config:base",
-    ":masterIssue",
+    ":dependencyDashboard",
     ":prConcurrentLimit10",
     ":separateMultipleMajorReleases",
     ":timezone(Asia/Tokyo)",


### PR DESCRIPTION
`:masterIssue` is renamed to `:dependencyDashboard`. While renovate migrates old preset name internally, it's better to use new preset name.

cf. https://github.com/renovatebot/renovate/pull/6729