### PR TITLE
validated with RENOVATE_CONFIG_FILE environment variable

### DIFF
--- a/.github/workflows/validate-config.yml
+++ b/.github/workflows/validate-config.yml
@@ -32,7 +32,5 @@ jobs:
         for file in *.json
         do
           echo "[CI] Let's validate $file"
-          cp $file renovate.json
-          npx --package renovate -c 'renovate-config-validator'
-          rm renovate.json
+          RENOVATE_CONFIG_FILE=${file} npx --package renovate -c 'renovate-config-validator'
         done


### PR DESCRIPTION
when renovate is enabled, renovate.json will be created by renovate bot. it is not good to delete renovate.json in the CI of this repository. So, i changed the environment variable to specify the file to be validated.