### PR TITLE
[Android] Accompanist is transferred to Google

### DIFF
--- a/groupAndroidPackages.json
+++ b/groupAndroidPackages.json
@@ -3,7 +3,7 @@
     {
       "groupName": "Accompanist",
       "matchPackagePatterns": [
-        "^dev\\.chrisbanes\\.accompanist:"
+        "^com\\.google\\.accompanist:"
       ]
     },
     {


### PR DESCRIPTION
https://github.com/google/accompanist/releases/tag/v0.7.0

> New home, package and group id: `com.google.accompanist`
