### PR TITLE
[Android] Rename Firebase group name

### DIFF
--- a/groupAndroidPackages.json
+++ b/groupAndroidPackages.json
@@ -82,7 +82,7 @@
       ]
     },
     {
-      "groupName": "Firebase",
+      "groupName": "Firebase Android",
       "matchPackageNames": [
         "com.google.android.gms:play-services-tagmanager"
       ],


### PR DESCRIPTION
For making it separated from Firebase iOS updates in monorepo.