### PR TITLE
fix a branch to run GitHub Actions

### DIFF
--- a/.github/workflows/validate-config.yml
+++ b/.github/workflows/validate-config.yml
@@ -2,7 +2,7 @@ name: Validate renovate config
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
 
 jobs:


### PR DESCRIPTION
The repository's stable branch is now **main** instead of *master*.

So GitHub Actions has not run against **main** branch.

