### PR TITLE
Add Kotest to Android package groupings

### DIFF
--- a/groupAndroidPackages.json
+++ b/groupAndroidPackages.json
@@ -150,7 +150,8 @@
     {
       "groupName": "Kotest",
       "matchPackagePatterns": [
-        "^io\\.kotest:"
+        "^io\\.kotest:",
+        "^io\\.kotest\\.extensions:"
       ]
     },
     {

--- a/groupAndroidPackages.json
+++ b/groupAndroidPackages.json
@@ -148,6 +148,12 @@
       ]
     },
     {
+      "groupName": "Kotest",
+      "matchPackagePatterns": [
+        "^io\\.kotest:"
+      ]
+    },
+    {
       "groupName": "Kotlin",
       "matchPackagePatterns": [
         "^org\\.jetbrains\\.kotlin:"


### PR DESCRIPTION
We may want to have a grouping for [Kotest](https://kotest.io/) and its extensions as well.

- Kotest: https://kotest.io/docs/quickstart
- Kotest Extensions: https://kotest.io/docs/extensions/extensions.html