### PR TITLE
Remove redundant settings

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,8 +1,6 @@
 {
   "extends": [
     "config:base",
-    ":dependencyDashboard",
-    ":prConcurrentLimit10",
     ":separateMultipleMajorReleases",
     ":timezone(Asia/Tokyo)",
     "github>hatena/renovate-config:schedule",
@@ -13,9 +11,6 @@
     "github>hatena/renovate-config:groupJest",
     "github>hatena/renovate-config:groupLinters",
     "github>hatena/renovate-config:postUpdateOptions"
-  ],
-  "ignorePresets": [
-    ":prConcurrentLimit20"
   ],
   "labels": [
     "renovate"


### PR DESCRIPTION
Remove redundant settings defined in [config:base](https://docs.renovatebot.com/presets-config/#configbase)

```
{
  "extends": [
    ":dependencyDashboard", <--
    ":semanticPrefixFixDepsChoreOthers",
    ":ignoreModulesAndTests",
    ":autodetectPinVersions",
    ":prHourlyLimit2",
    ":prConcurrentLimit10", <--
    "group:monorepos",
    "group:recommended",
    "workarounds:all"
  ]
}
```