### PR TITLE
[Android] GitHub Release reference for Dagger and Hilt

### DIFF
--- a/groupAndroidPackages.json
+++ b/groupAndroidPackages.json
@@ -179,6 +179,9 @@
       "groupName": "Dagger and Hilt",
       "matchPackagePatterns": [
         "^com\\.google\\.dagger:"
+      ],
+      "prBodyNotes": [
+        "### Release Notes\n\nhttps://github.com/google/dagger/releases/tag/dagger-{{{newVersion}}}"
       ]
     },
     {


### PR DESCRIPTION
**Platform**: Android
**Package(s)**: Dagger and Hilt

---

Looks like no release notes are detected for [Dagger](https://dagger.dev/) and [Hilt](https://dagger.dev/hilt/) automatically.
This manually appends a link to [GitHub release](https://github.com/google/dagger/releases) pointing to the updated version. Helps to see what's changed.
(ex. https://github.com/google/dagger/releases/tag/dagger-2.43.2 for version `2.43.2`)
