### PR TITLE
[Android] Set stabilityDays to 3 for Firebase Android

### DIFF
--- a/groupAndroidPackages.json
+++ b/groupAndroidPackages.json
@@ -213,7 +213,8 @@
       ],
       "prBodyNotes": [
         "### Release Notes\n\nhttps://firebase.google.com/support/release-notes/android#bom_v{{{replace '\\.' '-' newVersion}}}"
-      ]
+      ],
+      "stabilityDays": 3
     },
     {
       "groupName": "Flipper",


### PR DESCRIPTION
It will be a while before Firebase release notes are available.

- https://docs.renovatebot.com/configuration-options/#stabilitydays
- https://firebase.google.com/support/release-notes/android