### PR TITLE
Removed compose compiler from compose group

### DIFF
--- a/groupAndroidPackages.json
+++ b/groupAndroidPackages.json
@@ -256,7 +256,6 @@
       "matchPackagePatterns": [
         "^androidx\\.compose:",
         "^androidx\\.compose\\.animation:",
-        "^androidx\\.compose\\.compiler:",
         "^androidx\\.compose\\.foundation:",
         "^androidx\\.compose\\.material:",
         "^androidx\\.compose\\.runtime:",


### PR DESCRIPTION
- Compose compiler has become an independent version, I want to remove it from the group of other Compose libraries.
  - https://android-developers.googleblog.com/2022/06/independent-versioning-of-Jetpack-Compose-libraries.html