### PR TITLE
[cpanfile] Ignore `requires 'perl'`

### DIFF
--- a/cpanfile.json5
+++ b/cpanfile.json5
@@ -14,6 +14,10 @@
   packageRules: [
     {
       matchDatasources: ["cpan"],
+      excludePackageNames: ["perl"],
+    },
+    {
+      matchDatasources: ["cpan"],
       matchPackageNames: [
         "HTTP::Config",
         "HTTP::Headers",


### PR DESCRIPTION
Unfortunately current `cpan` datasource can't handle this.