### PR TITLE
[XcodeGen] Consider quotes

### DIFF
--- a/xcodegenSwiftPackages.json5
+++ b/xcodegenSwiftPackages.json5
@@ -4,8 +4,8 @@
     {
       fileMatch: ["(^|/)project\\.ya?ml$", "(^|/)[Xx]code[Gg]en/.+\\.ya?ml$"],
       matchStrings: [
-        "url: https:\\/\\/github\\.com\\/(?<depName>.*?)(\\.git)?\\s*version: (?<currentValue>.+?)\\s",
-        "github: (?<depName>.*?)\\s*version: (?<currentValue>.+?)\\s",
+        "url: https:\\/\\/github\\.com\\/(?<depName>.*?)(\\.git)?\\s*version: ['\"]?(?<currentValue>[^'\"]+?)['\"]?\\s",
+        "github: (?<depName>.*?)\\s*version: ['\"]?(?<currentValue>[^'\"]+?)['\"]?\\s",
       ],
       datasourceTemplate: "github-releases",
       extractVersionTemplate: "^v?(?<version>.*)$",


### PR DESCRIPTION
ref: #74 

- `version: '1.2.3'` 
- `version: "4.5"`

are now supported.