### PR TITLE
Update corporate site domain in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # renovate-config
 
-A [shareable config preset for Renovate](https://docs.renovatebot.com/config-presets/) used in [Hatena](https://hatenacorp.jp/).
+A [shareable config preset for Renovate](https://docs.renovatebot.com/config-presets/) used in [Hatena](https://hatena.co.jp/).
 
 ```json
 {


### PR DESCRIPTION
Follow up on the corporate site domain change from hatenacorp.jp to hatena.co.jp.