### PR TITLE
[XcodeGen] datasourceTemplate to `github-tags`

### DIFF
--- a/xcodegenSwiftPackages.json5
+++ b/xcodegenSwiftPackages.json5
@@ -7,7 +7,7 @@
         "url: https:\\/\\/github\\.com\\/(?<depName>.*?)(\\.git)?\\s*version: ['\"]?(?<currentValue>[^'\"]+?)['\"]?\\s",
         "github: (?<depName>.*?)\\s*version: ['\"]?(?<currentValue>[^'\"]+?)['\"]?\\s",
       ],
-      datasourceTemplate: "github-releases",
+      datasourceTemplate: "github-tags",
       extractVersionTemplate: "^v?(?<version>.*)$",
     },
   ],


### PR DESCRIPTION
`datasourceTemplate: "github-tags"` internally also performs similar processing to `"github-releases"` so it will cover a large scope.