### PR TITLE
[Action] Pin GitHub Actions with Digest for Security

### DIFF
--- a/default.json
+++ b/default.json
@@ -15,13 +15,9 @@
     "github>hatena/renovate-config:vulnerabilityAlerts",
     "github>hatena/renovate-config:pinGitHubActionDigests"
   ],
-  "labels": [
-    "renovate"
-  ],
+  "labels": ["renovate"],
   "dockerfile": {
-    "fileMatch": [
-      "(^|/)Dockerfile-[^/]*$"
-    ]
+    "fileMatch": ["(^|/)Dockerfile-[^/]*$"]
   },
   "npm": {
     "rangeStrategy": "bump"
@@ -29,10 +25,7 @@
   "packageRules": [
     {
       "groupName": "boto3",
-      "matchPackageNames": [
-        "boto3",
-        "botocore"
-      ]
+      "matchPackageNames": ["boto3", "botocore"]
     }
   ]
 }

--- a/default.json
+++ b/default.json
@@ -12,7 +12,8 @@
     "github>hatena/renovate-config:groupJest",
     "github>hatena/renovate-config:groupLinters",
     "github>hatena/renovate-config:postUpdateOptions",
-    "github>hatena/renovate-config:vulnerabilityAlerts"
+    "github>hatena/renovate-config:vulnerabilityAlerts",
+    "github>hatena/renovate-config:pinGitHubActionDigests"
   ],
   "labels": [
     "renovate"

--- a/pinGitHubActionDigests.json
+++ b/pinGitHubActionDigests.json
@@ -1,0 +1,9 @@
+{
+  "packageRules": [
+    {
+      "matchDepTypes": ["action"],
+      "excludePackagePrefixes": ["actions/"],
+      "pinDigests": true
+    }
+  ]
+}


### PR DESCRIPTION
When GitHub Actions are fixed by tags or versions, they remain potentially vulnerable to malicious changes.

- https://semgrep.dev/blog/2025/popular-github-action-tj-actionschanged-files-is-compromised/
- https://github.com/tj-actions/changed-files/issues/2464

Renovate has a helper that can automatically pin actions using digest hashes instead of tags. This PR implements digest pinning for better security.
We'll exclude official `actions/` repositories from this pinning as they're considered trusted sources.

- https://docs.renovatebot.com/modules/manager/github-actions/#digest-pinning-and-updating
- https://docs.renovatebot.com/presets-helpers/#helperspingithubactiondigests