### PR TITLE
Configured hilt matchDatasources

### DIFF
--- a/groupAndroidPackages.json
+++ b/groupAndroidPackages.json
@@ -202,6 +202,9 @@
       ],
       "prBodyNotes": [
         "### Release Notes\n\nhttps://github.com/google/dagger/releases/tag/dagger-{{{newVersion}}}"
+      ],
+      "matchDatasources": [
+        "maven"
       ]
     },
     {


### PR DESCRIPTION
## Overview
- This fixes the issue where the Hilt library and plugin were separate pull requests.
- It seems that the update destination of Hilt's Plugin is probably divided because it is looking at a different data source.