### PR TITLE
Fixed hilt plugin package pattern

### DIFF
--- a/groupAndroidPackages.json
+++ b/groupAndroidPackages.json
@@ -198,7 +198,7 @@
       "groupName": "Dagger and Hilt",
       "matchPackagePatterns": [
         "^com\\.google\\.dagger:",
-        "^com\\.google\\.dagger\\.hilt\\.android$"
+        "^com\\.google\\.dagger\\.hilt\\.android:"
       ],
       "prBodyNotes": [
         "### Release Notes\n\nhttps://github.com/google/dagger/releases/tag/dagger-{{{newVersion}}}"


### PR DESCRIPTION
## Overview
- I want to fix the issue where Hilt plugins are separated from library update pull requests.
- The package name of the Hilt Plugin is `com.google.dagger.hilt.android:com.google.dagger.hilt.android.gradle.plugin`, so I changed it to match.