### PR TITLE
Set `minimumReleaseAge` for npm packages

### DIFF
--- a/default.json
+++ b/default.json
@@ -13,7 +13,8 @@
     "github>hatena/renovate-config:groupLinters",
     "github>hatena/renovate-config:postUpdateOptions",
     "github>hatena/renovate-config:vulnerabilityAlerts",
-    "github>hatena/renovate-config:pinGitHubActionDigests"
+    "github>hatena/renovate-config:pinGitHubActionDigests",
+    "github>hatena/renovate-config:minimumReleaseAge"
   ],
   "labels": ["renovate"],
   "dockerfile": {

--- a/minimumReleaseAge.json
+++ b/minimumReleaseAge.json
@@ -1,0 +1,3 @@
+{
+  "minimumReleaseAge": "7 days"
+}

--- a/minimumReleaseAge.json
+++ b/minimumReleaseAge.json
@@ -1,3 +1,10 @@
 {
-  "minimumReleaseAge": "7 days"
+  "packageRules": [
+    {
+      "matchDatasources": [
+        "npm"
+      ],
+      "minimumReleaseAge": "7 days"
+    }
+  ]
 }


### PR DESCRIPTION
I want to set `minimumReleaseAge` for npm packages to mitigate supply chain attacks.

The value of option is debatable. Too short increases the likelihood of being affected by supply chain attacks. Conversely, too long delays incorporating vulnerability fixes.

For now, following https://zenn.dev/azu/articles/ad168118524135#%E4%BE%9D%E5%AD%98%E3%81%AE%E3%82%A2%E3%83%83%E3%83%97%E3%83%87%E3%83%BC%E3%83%88, I set it to `"7 days"`. It might be a bit long, but I think it's worth trying.

Additionally, I am applying this option only to npm, where the threat of supply chain attacks is high. I have postponed applying it to other platforms to avoid confusion.

It might be worth considering expanding the platforms to which this is applied in the future.