### PR TITLE
Apply minimumReleaseAgeBehaviour: timestamp-optional for ghcr.io images

### DIFF
--- a/default.json
+++ b/default.json
@@ -13,7 +13,8 @@
     "github>hatena/renovate-config:groupLinters",
     "github>hatena/renovate-config:postUpdateOptions",
     "github>hatena/renovate-config:vulnerabilityAlerts",
-    "github>hatena/renovate-config:pinGitHubActionDigests"
+    "github>hatena/renovate-config:pinGitHubActionDigests",
+    "github>hatena/renovate-config:minimumReleaseAgeBehaviour"
   ],
   "minimumReleaseAge": "7 days",
   "labels": ["renovate"],

--- a/minimumReleaseAgeBehaviour.json
+++ b/minimumReleaseAgeBehaviour.json
@@ -1,0 +1,13 @@
+{
+  "packageRules": [
+    {
+      "matchDepTypes": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "ghcr.io/**"
+      ],
+      "minimumReleaseAgeBehaviour": "timestamp-optional"
+    }
+  ]
+}


### PR DESCRIPTION
Since ghcr.io container images don't support `releaseTimestamp` , combining this with `minimumReleaseAge` under the default `minimumReleaseAgeBehaviour=timestamp-required` causes updates to be permanently marked as pending, and PRs were not being created.

```
DEBUG: Marking 4 release(s) as pending, as they do not have a releaseTimestamp and we're running with minimumReleaseAgeBehaviour=timestamp-required
{
  "depName": "ghcr.io/realm/swiftlint",
  "versions": [
    "0.65.0",
    "0.64.1",
    "0.64.0",
    "0.63.3"
  ],
  "check": "minimumReleaseAge"
}
```

I'd like to set `timestamp-optional` — which treats releases without a timestamp as stable — for ghcr.io images, to restore the previous PR creation behavior.

refs:
- https://docs.renovatebot.com/configuration-options/#minimumreleaseagebehaviour
- https://docs.renovatebot.com/key-concepts/minimum-release-age/#which-registries-support-release-timestamps