### PR TITLE
Fix to use matchDatasources

### DIFF
--- a/minimumReleaseAgeBehaviour.json
+++ b/minimumReleaseAgeBehaviour.json
@@ -1,7 +1,7 @@
 {
   "packageRules": [
     {
-      "matchDepTypes": [
+      "matchDatasources": [
         "docker"
       ],
       "matchPackageNames": [


### PR DESCRIPTION
`docker` was the datasource name, not the depType.